### PR TITLE
SetClassByPosition: Also replace old class references in CNWLevelStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ https://github.com/nwnxee/unified/compare/build8193.23...HEAD
 - Util: SetCurrentlyRunningEvent()
 
 ### Changed
-- N/A
+- ***API BREAKING*** Creature: SetClassByPosition by default replaces all occurrences of the old class in CNWLevelStats. This can be disabled with the argument 'bUpdateLevels'.
 
 ### Deprecated
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ https://github.com/nwnxee/unified/compare/build8193.23...HEAD
 - Util: SetCurrentlyRunningEvent()
 
 ### Changed
-- ***API BREAKING*** Creature: SetClassByPosition by default replaces all occurrences of the old class in CNWLevelStats. This can be disabled with the argument 'bUpdateLevels'.
+- ***ABI BREAKING*** Creature: SetClassByPosition by default replaces all occurrences of the old class in CNWLevelStats. This can be disabled with the argument 'bUpdateLevels'.
 
 ### Deprecated
 - N/A

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1048,18 +1048,19 @@ NWNX_EXPORT ArgumentStack SetClassByPosition(ArgumentStack&& args)
         const auto position = args.extract<int32_t>();
         const auto classID = args.extract<int32_t>();
         const auto bUpdateLevels = args.extract<int32_t>();
-        const auto classIDold = pCreature->m_pStats->GetClass(position);
           ASSERT_OR_THROW(position >= 0);
           ASSERT_OR_THROW(position <= 2);
           ASSERT_OR_THROW(classID >= Constants::ClassType::MIN);
           ASSERT_OR_THROW(classID <= Constants::ClassType::MAX);
 
+        // Save the old class id, then replace it with the new one
+        const auto classIDold = pCreature->m_pStats->GetClass(position);
         pCreature->m_pStats->SetClass(position, classID);
 
         if (bUpdateLevels)
         {
-            auto pLevelStats = pCreature->m_pStats->m_lstLevelStats;
-            for (auto *level : pLevelStats)
+            auto& levelStats = pCreature->m_pStats->m_lstLevelStats;
+            for (auto *level : levelStats)
             {
                 if (level->m_nClass == classIDold)
                 {

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1047,12 +1047,26 @@ NWNX_EXPORT ArgumentStack SetClassByPosition(ArgumentStack&& args)
     {
         const auto position = args.extract<int32_t>();
         const auto classID = args.extract<int32_t>();
+        const auto bUpdateLevels = args.extract<int32_t>();
+        const auto classIDold = pCreature->m_pStats->GetClass(position);
           ASSERT_OR_THROW(position >= 0);
           ASSERT_OR_THROW(position <= 2);
           ASSERT_OR_THROW(classID >= Constants::ClassType::MIN);
           ASSERT_OR_THROW(classID <= Constants::ClassType::MAX);
 
         pCreature->m_pStats->SetClass(position, classID);
+
+        if (bUpdateLevels)
+        {
+            auto pLevelStats = pCreature->m_pStats->m_lstLevelStats;
+            for (auto *level : pLevelStats)
+            {
+                if (level->m_nClass == classIDold)
+                {
+                    level->m_nClass = static_cast<uint8_t>(classID);
+                }
+            }
+        }
     }
     return {};
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -388,7 +388,9 @@ void NWNX_Creature_SetSkillRank(object creature, int skill, int rank);
 /// @param position Should be 0, 1, or 2 depending on how many classes the creature
 /// has and which is to be modified.
 /// @param classID A valid ID number in classes.2da and between 0 and 255.
-void NWNX_Creature_SetClassByPosition(object creature, int position, int classID);
+/// @param bUpdateLevels determines whether the method will replace all occurrences
+/// of the old class in CNWLevelStats with the new classID.
+void NWNX_Creature_SetClassByPosition(object creature, int position, int classID, int bUpdateLevels = TRUE);
 
 /// @brief Set the level at the given position for a creature.
 /// @note A creature should already have a class in that position.
@@ -1462,9 +1464,10 @@ void NWNX_Creature_SetSkillRank(object creature, int skill, int rank)
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetClassByPosition(object creature, int position, int classID)
+void NWNX_Creature_SetClassByPosition(object creature, int position, int classID, int bUpdateLevels = TRUE)
 {
     string sFunc = "SetClassByPosition";
+    NWNX_PushArgumentInt(bUpdateLevels);
     NWNX_PushArgumentInt(classID);
     NWNX_PushArgumentInt(position);
     NWNX_PushArgumentObject(creature);


### PR DESCRIPTION
While NWNX_Creature_SetClassByPosition correctly replaced the Class ID in the ClassList node, it did not change references to the old class in LvlStatList. This means that when trying to level up after having used the function, the game got confused, would throw a "[Server] Invalid number of multiclasses" error message and revert the levelup.

This commit modifies the function's default behavior to also update these old class references. Should this not be desired, the old functionality remains accessible via the bUpdateLevels argument.