### PR TITLE
Enable override to weapon power for DR piercing.

### DIFF
--- a/Plugins/Arelith/CMakeLists.txt
+++ b/Plugins/Arelith/CMakeLists.txt
@@ -5,7 +5,8 @@ if (${OPENSSL_FOUND})
         "Arelith.cpp"
         "Source/ArelithEvents.cpp"
         "Source/CanUse.cpp"
-        "Source/GetItemAppearance.cpp")
+        "Source/GetItemAppearance.cpp"
+        "Source/WeaponPower.cpp")
     target_link_libraries(Arelith ${OPENSSL_LIBRARIES})
     target_include_directories(Arelith PUBLIC ${OPENSSL_INCLUDE_DIR})
 endif()

--- a/Plugins/Arelith/Source/WeaponPower.cpp
+++ b/Plugins/Arelith/Source/WeaponPower.cpp
@@ -1,0 +1,35 @@
+#include "nwnx.hpp"
+
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/CNWSCombatRound.hpp"
+
+namespace Arelith {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static Hooks::Hook s_getWeaponPower;
+
+//called whenever weapon power for DR piercing is calculated
+int32_t WeaponPowerHook(CNWSCreature* thisPtr, CNWSObject* pTarget, int32_t bOffhand)
+{
+    static CExoString s_WeaponPowerOverride = "WEAPON_POWER_OVERRIDE";
+    CNWSItem* pAttackWeapon = nullptr;
+    int32_t nWeaponPower = 0;
+
+    pAttackWeapon = (bOffhand) ? thisPtr->m_pcCombatRound->GetCurrentAttackWeapon(2) :  thisPtr->m_pcCombatRound->GetCurrentAttackWeapon(0);
+
+    nWeaponPower = (int32_t)pAttackWeapon->m_ScriptVars.GetInt(s_WeaponPowerOverride);
+    int32_t nNormalPower = s_getWeaponPower->CallOriginal<int32_t>(thisPtr, pTarget, bOffhand);
+
+    return (nWeaponPower > nNormalPower) ? nWeaponPower : nNormalPower;
+}
+
+void WeaponPower() __attribute__((constructor));
+
+void WeaponPower()
+{
+    s_getWeaponPower = Hooks::HookFunction(Functions::_ZN12CNWSCreature14GetWeaponPowerEP10CNWSObjecti, (void*)&WeaponPowerHook, Hooks::Order::Final);
+}
+}

--- a/Plugins/Arelith/Source/WeaponPower.cpp
+++ b/Plugins/Arelith/Source/WeaponPower.cpp
@@ -19,8 +19,10 @@ int32_t WeaponPowerHook(CNWSCreature* thisPtr, CNWSObject* pTarget, int32_t bOff
     int32_t nWeaponPower = 0;
 
     pAttackWeapon = (bOffhand) ? thisPtr->m_pcCombatRound->GetCurrentAttackWeapon(2) :  thisPtr->m_pcCombatRound->GetCurrentAttackWeapon(0);
-
-    nWeaponPower = (int32_t)pAttackWeapon->m_ScriptVars.GetInt(s_WeaponPowerOverride);
+    if (pAttackWeapon) 
+    {
+        nWeaponPower = (int32_t)pAttackWeapon->m_ScriptVars.GetInt(s_WeaponPowerOverride);
+    }
     int32_t nNormalPower = s_getWeaponPower->CallOriginal<int32_t>(thisPtr, pTarget, bOffhand);
 
     return (nWeaponPower > nNormalPower) ? nWeaponPower : nNormalPower;


### PR DESCRIPTION
Weapons can have a power override for the purposes of beating DR which supersedes normal bonuses if it's higher. 

Combines with Arelith-Server/are-resources#4085 to enable the DR beating part of the item property DR Penetration.